### PR TITLE
[Example] Fix package.json

### DIFF
--- a/example/ProgressChart/package.json
+++ b/example/ProgressChart/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "art": "^0.10.0",
     "react-native": "^0.13.2",
-    "react-native-circular-progress": "0.0.1",
+    "react-native-circular-progress": "0.0.1"
   }
 }


### PR DESCRIPTION
In your example project, your package.json has a trailing comma for your final dependency listed, this gives an error when running ```npm install```