### PR TITLE
Fixed rendering bug

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -39,13 +39,11 @@ export default class CircularProgress extends React.Component {
           <Group rotation={rotation - 90} originX={size/2} originY={size/2}>
             <Shape d={circlePath}
               stroke={backgroundColor}
-              strokeCap="butt"
-              strokeDash={[(size - width) * Math.PI, 700]}
               strokeWidth={width} />
             <Shape d={circlePath}
               stroke={tintColor}
               strokeCap="butt"
-              strokeDash={[(size - width) * Math.PI * fill / 100, 700]}
+              strokeDash={[(size - width) * Math.PI * fill / 100, 9999]}
               strokeWidth={width} />
           </Group>
         </Surface>


### PR DESCRIPTION
I spotted a small rendering issue when attempting to represent a small amount of progress/fill on a larger progress component. You can reproduce this in the example app as per the screenshot below. Set the size of one of the progress indicators to 300 and set the fill to be small (e.g. less than 50) - the fill will appear to render as 2 dashes rather than one.

![simulator screen shot 1 jan 2016 20 46 12](https://cloud.githubusercontent.com/assets/17656/12072132/734c463e-b0c9-11e5-858c-8caab38c3b0c.png)

I was able to fix this by increasing the second stroke dash parameter to an arbitrarily higher value. I'm afraid I don't know where 700 came from, nor do I honestly truly understand this stroke functionality, so you may not find this to be an appropriate solution. However, I found this to work sufficiently for the cases I've tried.

![simulator screen shot 1 jan 2016 20 47 30](https://cloud.githubusercontent.com/assets/17656/12072133/b0f96df4-b0c9-11e5-9f32-3ffa35dee9fc.png)

I also observed that the stroke dash is not required for the background as we just want a solid arc. I removed the code and could not observe any difference in rendering behaviour in in the sample app or my own app so I've removed those properties.