### PR TITLE
Fix dependency conflict with react-native-svg... by using react-native-svg instead of ReactNativeART.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/bgryszko/react-native-circular-progress",
   "dependencies": {
-    "art": "^0.10.0"
+    "art": "^0.10.0",
+    "react-native-svg": "^4.0.0-rc"
   }
 }

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { View, Platform } from 'react-native';
-import { Surface, Shape, Path, Group } from '../../react-native/Libraries/ART/ReactNativeART';
+import Svg, { Path } from 'react-native-svg';
 import MetricsPath from 'art/metrics/path';
 
 export default class CircularProgress extends React.Component {
@@ -40,19 +40,26 @@ export default class CircularProgress extends React.Component {
 
     return (
       <View style={style}>
-        <Surface
+        <Svg
           width={size}
           height={size}>
-          <Group rotation={rotation - 90} originX={size/2} originY={size/2}>
-            <Shape d={backgroundPath}
-                   stroke={backgroundColor}
-                   strokeWidth={width}/>
-            <Shape d={circlePath}
-                   stroke={tintColor}
-                   strokeWidth={width}
-                   strokeCap="butt"/>
-          </Group>
-        </Surface>
+          <G
+            rotate={rotation - 90}
+            origin={(size/2),(size/2)}
+          >
+            <Path
+              d={backgroundPath}
+              stroke={backgroundColor}
+              strokeWidth={width}
+            />
+            <Path
+              d={circlePath}
+              stroke={tintColor}
+              strokeWidth={width}
+              strokeLinecap="butt"
+            />
+          </G>
+        </Svg>
         {
           children && children(fill)
         }

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { View, Platform } from 'react-native';
+import { View } from 'react-native';
 import Svg, { G, Path } from 'react-native-svg';
 
 export default class CircularProgress extends React.Component {


### PR DESCRIPTION
react-native-svg is cleaner imo, and also if you have react-native-svg, and react-native-circular-progress used on same project you will run into conflicts... so why not just use react-native-svg?!
