### PR TITLE
Added strokeCap, capWidth and capColor options

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -12,10 +12,10 @@ export default class CircularProgress extends React.Component {
       p.path.push(0, cx + r, cy);
       p.path.push(4, cx, cy, r, startDegree * Math.PI / 180, endDegree * Math.PI / 180, 1);
     } else {
-      // For Android we have to resort to drawing low-level Path primitives, as ART does not support 
+      // For Android we have to resort to drawing low-level Path primitives, as ART does not support
       // arbitrary circle segments. It also does not support strokeDash.
       // Furthermore, the ART implementation seems to be buggy/different than the iOS one.
-      // MoveTo is not needed on Android 
+      // MoveTo is not needed on Android
       p.path.push(4, cx, cy, r, startDegree * Math.PI / 180, (startDegree - endDegree) * Math.PI / 180, 0);
     }
     return p;
@@ -32,25 +32,35 @@ export default class CircularProgress extends React.Component {
   }
 
   render() {
-    const { size, width, tintColor, backgroundColor, style, rotation, children } = this.props;
-    const backgroundPath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, 0, 360);
+    const { size, width, tintColor, backgroundColor, style, rotation, children, capWidth, capColor, strokeCap } = this.props;
+    const borderWidth = capWidth > width ? capWidth : width;
+    const radius = (size-borderWidth)/2;
+    const center = size/2;
+    const backgroundPath = this.circlePath(center, center, radius, 0, 360);
 
     const fill = this.extractFill(this.props.fill);
-    const circlePath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, 0, 360 * fill / 100);
+    const circlePath = this.circlePath(center, center, radius, 0, 360 * fill / 100);
+
+    const radian = Math.PI * fill/50;
+    const capX = radius * Math.cos(radian) + center;
+    const capY = radius * Math.sin(radian) + center;
 
     return (
       <View style={style}>
         <Surface
           width={size}
           height={size}>
-          <Group rotation={rotation - 90} originX={size/2} originY={size/2}>
+          <Group rotation={rotation - 90} originX={center} originY={center}>
             <Shape d={backgroundPath}
                    stroke={backgroundColor}
                    strokeWidth={width}/>
             <Shape d={circlePath}
                    stroke={tintColor}
                    strokeWidth={width}
-                   strokeCap="butt"/>
+                   strokeCap={strokeCap}/>
+           <Shape d={this.circlePath(capX, capY, capWidth/4, 0, 360)}
+                   stroke={capColor}
+                   strokeWidth={capWidth/2}/>
           </Group>
         </Surface>
         {
@@ -66,6 +76,9 @@ CircularProgress.propTypes = {
   size: PropTypes.number.isRequired,
   fill: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
+  strokeCap: PropTypes.string,
+  capColor: PropTypes.string,
+  capWidth: PropTypes.number,
   tintColor: PropTypes.string,
   backgroundColor: PropTypes.string,
   rotation: PropTypes.number,
@@ -75,5 +88,8 @@ CircularProgress.propTypes = {
 CircularProgress.defaultProps = {
   tintColor: 'black',
   backgroundColor: '#e4e4e4',
-  rotation: 90
+  rotation: 90,
+  strokeCap: 'butt',
+  capColor: 'black',
+  capWidth: 0
 }


### PR DESCRIPTION
- Strokecap can now be customised through props
- I wanted a circular cap at the end of the progress. Added capwidth and capcolor options to accommodate that
- Introduced couple of variables (center, radius)

All new properties are optional. Old behaviour is retained if new properties are not specified.
