### PR TITLE
Use absolute imports for ART

### DIFF
--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import React, { PropTypes } from 'react';
 import { View, ViewPropTypes, Platform, ART } from 'react-native';
 const { Surface, Shape, Path, Group } = ART;
 import MetricsPath from 'art/metrics/path';

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import { View, Platform } from 'react-native';
-import { Surface, Shape, Path, Group } from '../../react-native/Libraries/ART/ReactNativeART';
+import { View, Platform, ART } from 'react-native';
+const { Surface, Shape, Path, Group } = ART;
 import MetricsPath from 'art/metrics/path';
 
 export default class CircularProgress extends React.Component {


### PR DESCRIPTION
Because you get an import error when this is used as a dependency to another package.