### PR TITLE
Added peer dependencies on dependents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
   "dependencies": {
     "art": "^0.10.1",
     "prop-types": "^15.6.0"
+  },
+  "peerDependencies": {
+    "react": ">= 15 || ~16.0.0-0",
+    "react-native": ">=0.39"
   }
 }


### PR DESCRIPTION
This helps tools like yarn workspaces work correctly when detecting dependencies.
I specified react native >=0.39 because that's what the example app uses.