### PR TITLE
rnsvg dep ==> peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/bgryszko/react-native-circular-progress",
   "dependencies": {
-    "prop-types": "^15.6.0",
-    "react-native-svg": "^6.3.1"
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": ">=16.0.0",
-    "react-native": ">=0.39.0"
+    "react-native": ">=0.39.0",
+    "react-native-svg": "^6.3.1"
   }
 }


### PR DESCRIPTION
I ran into some problems with react-native-svg being installed in the node_modules/react-native-circular-progress folder, which was a problem when version numbers were clashing.